### PR TITLE
Make package build on xenial

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+debathena-chrony-config (1.5) unstable; urgency=low
+
+  * Modify package build script to accomodate the new pool configuration
+    directive and build on Ubuntu Xenial Xerus.
+
+ -- Lizhou Sha <slz@mit.edu>  Sat, 18 Jun 2016 07:54:38 -0400
+
 debathena-chrony-config (1.4) unstable; urgency=low
 
   [ Jonathan Reed ]

--- a/debian/transform_chrony.conf.debathena
+++ b/debian/transform_chrony.conf.debathena
@@ -1,4 +1,5 @@
 #!/usr/bin/perl -0p
-s/^server .*$/###SERVER/m or die;
+s/^server .*$/###SERVER/m or s/^pool .*$/###SERVER/m or die;
 s/^server .*$//mg;
+s/^pool .*$//mg;
 s/###SERVER/server TIME.MIT.EDU/ or die;


### PR DESCRIPTION
Xenial's `chrony.conf` only ships with a `pool` directive and no `server` directive, causing the build script to fail. This change finds all `server` and `pool` directives and replace them with a single line of `server TIME.MIT.EDU`.
